### PR TITLE
feat: Post login keycloak code authoization

### DIFF
--- a/src/app/auth/authorize/page.tsx
+++ b/src/app/auth/authorize/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { Suspense, useEffect } from 'react';
+import { useMutation } from 'react-query';
+import { authorizeLogin } from '@/service/auth';
+import { useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
+import useCurentUrl from '@/hooks/useCurentUrl';
+import { Spinner } from '@nextui-org/react';
+
+export default function AuthorizePage() {
+  return (
+    <Suspense fallback="Loading...">
+      <AuthorizeLoginComponent />
+    </Suspense>
+  );
+}
+
+const AuthorizeLoginComponent = () => {
+  const navigate = useRouter().push;
+
+  const searchParams = useSearchParams();
+  const params = new URLSearchParams(searchParams);
+
+  const { domainUrl } = useCurentUrl();
+  const LOGIN_REDIRECT_URL = `${domainUrl}/auth/authorize`;
+
+  params.append('redirect_uri', LOGIN_REDIRECT_URL);
+  const authorizeMutation = useMutation({
+    mutationFn: () => authorizeLogin(params, LOGIN_REDIRECT_URL),
+    onSuccess: () => {
+      const next_url = searchParams.get('next');
+      if (next_url) {
+        navigate(next_url);
+        return;
+      }
+
+      navigate('/dashboard');
+    },
+  });
+
+  useEffect(() => {
+    authorizeMutation.mutate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <main className="flex flex-col items-center justify-center h-screen space-y-4">
+      <Spinner size="lg" />
+      <p className="text-primary-500">Checking your credentials...</p>
+    </main>
+  );
+};

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useAuth } from '@/hooks/useAuth';
+import useCurentUrl from '@/hooks/useCurentUrl';
 import { logout } from '@/service/auth';
 import {
   Navbar,
@@ -20,18 +21,6 @@ import { IconUser } from '@tabler/icons-react';
 import { useRouter } from 'next/navigation';
 import { useMutation } from 'react-query';
 
-const NAVBAR_LINKS = [
-  { name: 'About', href: '/about', withLogin: true, withLogout: true },
-  { name: 'Docs', href: '/docs', withLogin: true, withLogout: true },
-  { name: 'Infrastructure', href: '/infrastructure', withLogin: true, withLogout: true },
-  {
-    name: 'Sign In',
-    href: `${process.env.NEXT_PUBLIC_SHOP_MANAGEMENT_API_URL}/auth/public/login`,
-    withLogin: false,
-    withLogout: true,
-  },
-];
-
 const NAVBAR_BUTTONS = [{ name: 'Sign Up', href: '/signup', withLogin: false, withLogout: true }];
 
 const NAVBAR_DROPDOWN_SETTINGS = [
@@ -43,6 +32,20 @@ const NavBar = () => {
   const router = useRouter();
 
   const { status, userData, setUserData } = useAuth();
+
+  const { domainUrl } = useCurentUrl();
+  const LOGIN_REDIRECT_URL = `${domainUrl}/auth/authorize`;
+  const NAVBAR_LINKS = [
+    { name: 'About', href: '/about', withLogin: true, withLogout: true },
+    { name: 'Docs', href: '/docs', withLogin: true, withLogout: true },
+    { name: 'Infrastructure', href: '/infrastructure', withLogin: true, withLogout: true },
+    {
+      name: 'Sign In',
+      href: `${process.env.NEXT_PUBLIC_SHOP_MANAGEMENT_API_URL}/auth/public/login?redirect_uri=${LOGIN_REDIRECT_URL}`,
+      withLogin: false,
+      withLogout: true,
+    },
+  ];
 
   const logoutMutation = useMutation({
     mutationFn: logout,

--- a/src/hooks/useCurentUrl.ts
+++ b/src/hooks/useCurentUrl.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+const useCurrentUrl = () => {
+  const [currentUrl, setCurrentUrl] = useState('');
+  const [domainUrl, setDomainUrl] = useState('');
+
+  useEffect(() => {
+    setCurrentUrl(window.location.href);
+    setDomainUrl(window.location.origin);
+
+    const handleUrlChange = () => {
+      setCurrentUrl(window.location.href);
+      setDomainUrl(window.location.origin);
+    };
+
+    window.addEventListener('popstate', handleUrlChange);
+    return () => window.removeEventListener('popstate', handleUrlChange);
+  }, []);
+
+  return {
+    currentUrl,
+    domainUrl,
+  };
+};
+
+export default useCurrentUrl;

--- a/src/service/auth/index.ts
+++ b/src/service/auth/index.ts
@@ -20,3 +20,14 @@ export const getCurrentSession = async (token: string): Promise<GetCurrentSessio
 export const logout = async (token: string): Promise<void> => {
   await getFetcher(token).post('/private/logout');
 };
+
+export const authorizeLogin = async (queryParams: URLSearchParams, validation_uri: string): Promise<void> => {
+  const params = new URLSearchParams(queryParams);
+  params.append('validation_uri', validation_uri);
+  return (
+    await axios.post(API_URL + '/auth/public/authorize', null, {
+      params: params,
+      withCredentials: true,
+    })
+  ).data;
+};


### PR DESCRIPTION
## ✨ **Features**:
- New token management flow 
  ```mermaid
  sequenceDiagram
      participant User
      participant Client
      participant AuthServer as Admin Server
      participant Keycloak
  
      User->>Client: Request to log in
      Client->>AuthServer: GET /auth/public/login?redirect_uri=client_redirect_uri&next=optional_route_post_auth
      AuthServer-->>User: Redirect to Keycloak Login
      User->>Keycloak: Login Credentials
      Keycloak-->>User: Redirect to client_redirect_uri with code=keycloak_auth_code
      User->>Client: Access client_redirect_uri?code=keycloak_auth_code
      Client->>AuthServer: POST /auth/public/authorize?code=keycloak_auth_code&validation_uri=client_redirect_uri&next=optional_route_post_auth
      AuthServer-->>Client: Set cookies with auth tokens
      Client->>User: Redirect to optional_route_post_auth (User Authenticated)
  ```

- New page and service to authorize sessions using keycloak authorization grant codes

> [!NOTE]  
> The validation URI must match the redirect URI used in the login endpoint. If a 'next' URI is required, it must also be included in the authorization endpoint. Failing to do so will result in authentication failure.


## ♻️  **Refactors**:
- Updated navbar login link to include redirect uri